### PR TITLE
Use layout constraints instead of Orientation

### DIFF
--- a/lib/view/widgets/master_details_page.dart
+++ b/lib/view/widgets/master_details_page.dart
@@ -21,21 +21,20 @@ class _MasterDetailPageState extends State<MasterDetailPage> {
 
   @override
   Widget build(BuildContext context) {
-    return OrientationBuilder(
-      builder: (context, orientation) {
-        switch (orientation) {
-          case Orientation.portrait:
-            return PortraitLayout(
-              selectedIndex: _index,
-              pages: pageItems,
-              onSelected: _setIndex,
-            );
-          case Orientation.landscape:
-            return LandscapeLayout(
-              selectedIndex: _index == -1 ? _previousIndex : _index,
-              pages: pageItems,
-              onSelected: _setIndex,
-            );
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth < 620) {
+          return PortraitLayout(
+            selectedIndex: _index,
+            pages: pageItems,
+            onSelected: _setIndex,
+          );
+        } else {
+          return LandscapeLayout(
+            selectedIndex: _index == -1 ? _previousIndex : _index,
+            pages: pageItems,
+            onSelected: _setIndex,
+          );
         }
       },
     );


### PR DESCRIPTION
With the current orientation builder the view is switched to potrait if the height has a certain factor relative to the height. This does not really fit to the desktop. What it is better is if the width is less than a certrain amount switch to portrait layout

Before:
![orientationbuilder](https://user-images.githubusercontent.com/15329494/137146041-b4aaa85d-62e4-4be9-8aca-cf52449571a5.gif)


After:
![layoutbuilder](https://user-images.githubusercontent.com/15329494/137146070-d0ec5d8a-ddb5-41f7-afc6-e49e8a55fe23.gif)

@jpnurmi are you okay with this? Asking because it's code from your repo :)