### PR TITLE
InfoPage: move pdf_api into pdf_service

### DIFF
--- a/lib/services/pdf_service.dart
+++ b/lib/services/pdf_service.dart
@@ -4,7 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:pdf/widgets.dart';
 
-class PdfApi {
+class PdfService {
   static Future<File> generateSystemData(
     String osName,
     String osVersion,

--- a/lib/view/pages/info/info_page.dart
+++ b/lib/view/pages/info/info_page.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:open_file/open_file.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
-import 'package:settings/api/pdf_api.dart';
+import 'package:settings/services/pdf_service.dart';
 import 'package:settings/constants.dart';
 import 'package:settings/l10n/l10n.dart';
 import 'package:settings/services/hostname_service.dart';
@@ -135,7 +135,7 @@ class _InfoPageState extends State<InfoPage> {
                 label: const Text('Export to PDF'),
                 onPressed: () async {
                   // ignore: unused_local_variable
-                  final pdfFile = await PdfApi.generateSystemData(
+                  final pdfFile = await PdfService.generateSystemData(
                     model.osName,
                     model.osVersion,
                     model.kernelVersion,


### PR DESCRIPTION
- follow the service dir convention we currently use for non-GUI-related, reuseable pieces of code. This service could be re-used in the printer page.