### PR TITLE
Grab keyboard for entering shortcuts

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:settings/services/display/display_service.dart';
 import 'package:settings/services/hostname_service.dart';
 import 'package:settings/services/house_keeping_service.dart';
 import 'package:settings/services/input_source_service.dart';
+import 'package:settings/services/keyboard_service.dart';
 import 'package:settings/services/locale_service.dart';
 import 'package:settings/services/power_profile_service.dart';
 import 'package:settings/services/power_settings_service.dart';
@@ -37,6 +38,9 @@ void main() async {
         Provider<HostnameService>(
           create: (_) => HostnameService(),
           dispose: (_, service) => service.dispose(),
+        ),
+        Provider<KeyboardService>(
+          create: (_) => KeyboardMethodChannel(),
         ),
         Provider<NetworkManagerClient>.value(value: networkManagerClient),
         Provider<PowerProfileService>(

--- a/lib/services/keyboard_service.dart
+++ b/lib/services/keyboard_service.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/services.dart';
+
+const _methodChannel = MethodChannel('settings/keyboard');
+
+abstract class KeyboardService {
+  Future<bool> grab();
+  Future<bool> ungrab();
+}
+
+class KeyboardMethodChannel implements KeyboardService {
+  @override
+  Future<bool> grab() {
+    return _methodChannel
+        .invokeMethod<bool>('grabKeyboard')
+        .then((value) => value ?? false);
+  }
+
+  @override
+  Future<bool> ungrab() async {
+    return _methodChannel
+        .invokeMethod<bool>('ungrabKeyboard')
+        .then((value) => value ?? false);
+  }
+}

--- a/lib/view/pages/keyboard/keyboard_shortcut_row.dart
+++ b/lib/view/pages/keyboard/keyboard_shortcut_row.dart
@@ -51,9 +51,9 @@ class _KeyboardShortcutRowState extends State<KeyboardShortcutRow> {
         ),
       ),
       borderRadius: BorderRadius.circular(4.0),
-      onTap: () {
+      onTap: () async {
         final oldShortcut = model.getShortcutStrings(widget.shortcutId);
-        // TODO: grab the keyboard from gnome-shell
+        await model.grabKeyboard();
         showDialog<List<String>>(
           context: context,
           builder: (_) => StatefulBuilder(builder: (context, setState) {
@@ -76,6 +76,7 @@ class _KeyboardShortcutRowState extends State<KeyboardShortcutRow> {
         ).then((shortcut) {
           keys.clear();
           model.setShortcut(widget.shortcutId, shortcut ?? oldShortcut);
+          model.ungrabKeyboard();
         });
       },
     );

--- a/lib/view/pages/keyboard/keyboard_shortcuts_model.dart
+++ b/lib/view/pages/keyboard/keyboard_shortcuts_model.dart
@@ -1,11 +1,16 @@
 import 'package:flutter/foundation.dart';
+import 'package:settings/services/keyboard_service.dart';
 import 'package:settings/services/settings_service.dart';
 
 class KeyboardShortcutsModel extends ChangeNotifier {
   final String schemaId;
 
-  KeyboardShortcutsModel(SettingsService service, {required this.schemaId})
-      : _shortcutSettings = service.lookup(schemaId) {
+  KeyboardShortcutsModel({
+    required KeyboardService keyboard,
+    required SettingsService settings,
+    required this.schemaId,
+  })  : _keyboard = keyboard,
+        _shortcutSettings = settings.lookup(schemaId) {
     _shortcutSettings?.addListener(notifyListeners);
   }
 
@@ -15,7 +20,11 @@ class KeyboardShortcutsModel extends ChangeNotifier {
     super.dispose();
   }
 
+  final KeyboardService _keyboard;
   final Settings? _shortcutSettings;
+
+  Future<bool> grabKeyboard() => _keyboard.grab();
+  Future<bool> ungrabKeyboard() => _keyboard.ungrab();
 
   List<String> getShortcutStrings(String shortcutId) {
     final keys = _shortcutSettings?.stringArrayValue(shortcutId);

--- a/lib/view/pages/keyboard/keyboard_shortcuts_page.dart
+++ b/lib/view/pages/keyboard/keyboard_shortcuts_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/constants.dart';
 import 'package:settings/schemas/schemas.dart';
+import 'package:settings/services/keyboard_service.dart';
 import 'package:settings/services/settings_service.dart';
 import 'package:settings/view/pages/keyboard/keyboard_shortcut_row.dart';
 import 'package:settings/view/pages/keyboard/keyboard_shortcuts_model.dart';
@@ -12,13 +13,14 @@ class KeyboardShortcutsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final service = Provider.of<SettingsService>(context, listen: false);
-
     return YaruPage(
       children: [
         ChangeNotifierProvider(
-          create: (_) =>
-              KeyboardShortcutsModel(service, schemaId: schemaWmKeybindings),
+          create: (_) => KeyboardShortcutsModel(
+            keyboard: context.read<KeyboardService>(),
+            settings: context.read<SettingsService>(),
+            schemaId: schemaWmKeybindings,
+          ),
           child: const YaruSection(
             width: kDefaultWidth,
             headline: 'Navigation Shortcuts',
@@ -35,8 +37,11 @@ class KeyboardShortcutsPage extends StatelessWidget {
           ),
         ),
         ChangeNotifierProvider(
-            create: (_) => KeyboardShortcutsModel(service,
-                schemaId: schemaGnomeShellKeybinding),
+            create: (_) => KeyboardShortcutsModel(
+                  keyboard: context.read<KeyboardService>(),
+                  settings: context.read<SettingsService>(),
+                  schemaId: schemaGnomeShellKeybinding,
+                ),
             child: const YaruSection(
               width: kDefaultWidth,
               headline: 'System',

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -169,7 +169,7 @@ static void my_application_activate(GApplication* application) {
   g_autoptr(FlMethodChannel) keyboard_channel = fl_method_channel_new(
       messenger, "settings/keyboard", FL_METHOD_CODEC(codec));
   fl_method_channel_set_method_call_handler(
-      keyboard_channel, keyboard_method_call_cb, self, g_object_unref);
+      keyboard_channel, keyboard_method_call_cb, self, nullptr);
 
   gtk_widget_show(GTK_WIDGET(window));
   gtk_widget_show(GTK_WIDGET(view));


### PR DESCRIPTION
NOTE: VS Code forces `GDK_BACKEND=x11` which breaks keyboard grabbing
on Wayland. For testing shortcuts on Wayland, run the app from outside of
VS Code. Alternatively, you can also set `GDK_BACKEND=wayland` for the
launch config even though it may result in strange behavior such as the
window titlebar buttons being aligned to the wrong side etc.

Close: #102