### PR TITLE
PowerProfileService: clean up UI dependencies

### DIFF
--- a/lib/services/power_profile_service.dart
+++ b/lib/services/power_profile_service.dart
@@ -1,11 +1,7 @@
 import 'dart:async';
 
 import 'package:dbus/dbus.dart';
-import 'package:flutter/material.dart';
-import 'package:settings/l10n/l10n.dart';
-import 'package:settings/utils.dart';
-import 'package:yaru_colors/yaru_colors.dart';
-import 'package:yaru_icons/yaru_icons.dart';
+import 'package:meta/meta.dart';
 
 @visibleForTesting
 const kPowerProfilesInterface = 'net.hadess.PowerProfiles';
@@ -16,66 +12,7 @@ const kPowerProfilesPath = '/net/hadess/PowerProfiles';
 enum PowerProfile {
   performance,
   balanced,
-  powerSaver;
-
-  // TODO: localize
-  String localize(AppLocalizations l10n) {
-    switch (this) {
-      case PowerProfile.performance:
-        return 'Performance';
-      case PowerProfile.balanced:
-        return 'Balanced';
-      case PowerProfile.powerSaver:
-        return 'Power save';
-    }
-  }
-
-  // TODO: localize
-  String localizeDescription(AppLocalizations l10n) {
-    switch (this) {
-      case PowerProfile.performance:
-        return 'High performance and power usage.';
-      case PowerProfile.balanced:
-        return 'Standard performance and power usage.';
-      case PowerProfile.powerSaver:
-        return 'Reduced performance and power usage.';
-    }
-  }
-
-  IconData getIcon() {
-    switch (this) {
-      case PowerProfile.performance:
-        return YaruIcons.meter_5;
-      case PowerProfile.balanced:
-        return YaruIcons.meter_3;
-      case PowerProfile.powerSaver:
-        return YaruIcons.meter_1;
-    }
-  }
-
-  Color getColor(bool light) {
-    switch (this) {
-      case PowerProfile.performance:
-        return light ? YaruColors.red : lighten(YaruColors.red, 30);
-      case PowerProfile.balanced:
-        return light ? YaruColors.inkstone : YaruColors.porcelain;
-      case PowerProfile.powerSaver:
-        return light ? YaruColors.success : lighten(YaruColors.success, 30);
-    }
-  }
-
-  String? toProfileString() {
-    switch (this) {
-      case PowerProfile.performance:
-        return 'performance';
-      case PowerProfile.balanced:
-        return 'balanced';
-      case PowerProfile.powerSaver:
-        return 'power-saver';
-      default:
-        return null;
-    }
-  }
+  powerSaver,
 }
 
 class PowerProfileService {
@@ -159,6 +96,21 @@ extension _ProfileValue on String {
         return PowerProfile.balanced;
       case 'power-saver':
         return PowerProfile.powerSaver;
+      default:
+        return null;
+    }
+  }
+}
+
+extension _ProfileString on PowerProfile {
+  String? toProfileString() {
+    switch (this) {
+      case PowerProfile.performance:
+        return 'performance';
+      case PowerProfile.balanced:
+        return 'balanced';
+      case PowerProfile.powerSaver:
+        return 'power-saver';
       default:
         return null;
     }

--- a/lib/view/pages/power/power_profile_section.dart
+++ b/lib/view/pages/power/power_profile_section.dart
@@ -5,6 +5,7 @@ import 'package:settings/l10n/l10n.dart';
 import 'package:settings/services/power_profile_service.dart';
 import 'package:settings/view/pages/power/power_profile_model.dart';
 import 'package:settings/view/pages/power/power_profile_widgets.dart';
+import 'package:settings/view/pages/power/power_profile_x.dart';
 import 'package:settings/view/settings_section.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 

--- a/lib/view/pages/power/power_profile_widgets.dart
+++ b/lib/view/pages/power/power_profile_widgets.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:settings/services/power_profile_service.dart';
+import 'package:settings/view/pages/power/power_profile_x.dart';
 
 class ProfileModeTitle extends StatelessWidget {
   const ProfileModeTitle({

--- a/lib/view/pages/power/power_profile_x.dart
+++ b/lib/view/pages/power/power_profile_x.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/widgets.dart';
+import 'package:settings/l10n/l10n.dart';
+import 'package:settings/services/power_profile_service.dart';
+import 'package:settings/utils.dart';
+import 'package:yaru_colors/yaru_colors.dart';
+import 'package:yaru_icons/yaru_icons.dart';
+
+extension PowerProfileX on PowerProfile {
+  // TODO: localize
+  String localize(AppLocalizations l10n) {
+    switch (this) {
+      case PowerProfile.performance:
+        return 'Performance';
+      case PowerProfile.balanced:
+        return 'Balanced';
+      case PowerProfile.powerSaver:
+        return 'Power save';
+    }
+  }
+
+  // TODO: localize
+  String localizeDescription(AppLocalizations l10n) {
+    switch (this) {
+      case PowerProfile.performance:
+        return 'High performance and power usage.';
+      case PowerProfile.balanced:
+        return 'Standard performance and power usage.';
+      case PowerProfile.powerSaver:
+        return 'Reduced performance and power usage.';
+    }
+  }
+
+  IconData getIcon() {
+    switch (this) {
+      case PowerProfile.performance:
+        return YaruIcons.meter_5;
+      case PowerProfile.balanced:
+        return YaruIcons.meter_3;
+      case PowerProfile.powerSaver:
+        return YaruIcons.meter_1;
+    }
+  }
+
+  Color getColor(bool light) {
+    switch (this) {
+      case PowerProfile.performance:
+        return light ? YaruColors.red : lighten(YaruColors.red, 30);
+      case PowerProfile.balanced:
+        return light ? YaruColors.inkstone : YaruColors.porcelain;
+      case PowerProfile.powerSaver:
+        return light ? YaruColors.success : lighten(YaruColors.success, 30);
+    }
+  }
+}


### PR DESCRIPTION
This is a preparation step for translating the Power page (#375).

Services are low-level classes that don't need to know about anything UI-related, such as translations, icons, or colors. At the same time, the string<->enum conversion is internal to the service and not something the UI should care about.