### PR TITLE
Require specific 0.2.7 version of yaru_icons

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1000,7 +1000,7 @@ packages:
       name: yaru_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.6"
+    version: "0.2.7"
   yaru_settings:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   xml: ^5.3.1
   yaru: ^0.4.1
   yaru_colors: ^0.1.0
-  yaru_icons: ^0.2.1
+  yaru_icons: ^0.2.7
   yaru_settings:
     path: packages/yaru_settings
   yaru_widgets: ^2.0.0-beta-1


### PR DESCRIPTION
Just require `yaru_icons: 0.2.7` to get the icon alignement patch.