### PR TITLE
Wallpaper_page: remove const from non const constructor

### DIFF
--- a/lib/view/pages/wallpaper/wallpaper_page.dart
+++ b/lib/view/pages/wallpaper/wallpaper_page.dart
@@ -210,7 +210,7 @@ class _AddWallpaperTile extends StatelessWidget {
         onTap: () async {
           final picPath = await openFile(
             acceptedTypeGroups: [
-              const XTypeGroup(
+              XTypeGroup(
                 label: 'images',
                 extensions: <String>['jpg', 'png'],
               )


### PR DESCRIPTION
The `XTypeGroup` has surly been updated in the library to be non constant.

Fixes #397