### PR TITLE
Add the title and copyright info

### DIFF
--- a/lib/view/pages/wallpaper/wallpaper_model.dart
+++ b/lib/view/pages/wallpaper/wallpaper_model.dart
@@ -179,46 +179,78 @@ class WallpaperModel extends SafeChangeNotifier {
 
     // Load the user's Documents Directory to store the downloaded wallpapers
     final directory = await getApplicationDocumentsDirectory();
-    final file = File('${directory.path}/${imageOfTheDayProvider.name}.jpeg');
 
-    final Map providers = {
-      'bing': {
-        'apiUrl': _bingApiUrl,
-        'getImageUrl': (jsonData) {
-          return _bingUrl + json.decode(jsonData.body)['images'][0]['url'];
-        }
-      },
-      'nasa': {
-        'apiUrl': _nasaUrl, //The api uses my own api_key
-        'getImageUrl': (jsonData) {
-          return json.decode(jsonData.body)['url'];
-        }
-      },
-    };
-
-    //Get the url of the day using the apiUrl in the providers Map
-    Future<String> getImageUrl() async {
-      Map currentProvider = providers[imageOfTheDayProvider.name];
-      http.Response imageMetadataResponse =
-          await http.get(Uri.parse(currentProvider['apiUrl']));
-      return currentProvider['getImageUrl'](imageMetadataResponse);
+    ImageProvider getProvider(ImageOfTheDayProvider providerName) {
+      switch (providerName) {
+        case ImageOfTheDayProvider.bing:
+          {
+            return ImageProvider(
+              apiUrl: _bingApiUrl,
+              getImageUrl: (json) {
+                return _bingUrl + json['images'][0]['url'];
+              },
+              getImageMetadata: (json) => json['images'][0]['copyright'].replaceAll('/', ' - '));
+          }
+        case ImageOfTheDayProvider.nasa: {
+            return ImageProvider(
+              apiUrl: _nasaUrl,
+              getImageUrl: (json) => json['url'],
+              getImageMetadata: (json) => '${json['title']}  (© ${json['copyright']})');
+          }
+      }
     }
 
-    String imageUrl = '';
-    imageUrl = await getImageUrl().onError((error, stackTrace) {
-      return errorMessage = error.toString();
-    });
+    //Get the url of the day using the apiUrl in the providers Map
+    Future<ImageModel> getImageUrl() async {
+      ImageProvider currentProvider = getProvider(imageOfTheDayProvider);
+      http.Response imageMetadataResponse =
+          await http.get(Uri.parse(currentProvider.apiUrl));
+      var decodedJson = json.decode(imageMetadataResponse.body);
+      return ImageModel(
+        imageUrl: currentProvider.getImageUrl(decodedJson),
+        imageMetadata: currentProvider
+            .getImageMetadata(decodedJson),
+      );
+    }
+    ImageModel image = await getImageUrl();
+
+    //TODO: Save the images to a more suitable location
+    String path = '${directory.path}/ImageOfTheDay/${imageOfTheDayProvider.name}/';
+    bool exists = await Directory(path).exists();
+    if(!exists) {
+      await Directory(path).create(recursive: true);
+    }
+    //TODO: Embed the copyright info in the metadata instead of the filename
+    final file = File(path + image.imageMetadata + '.jpeg');
 
     // Refetch if the image doesn't exist or the current image is older than a day
     if (!file.existsSync() ||
         file.lastModifiedSync().day != DateTime.now().day) {
-      var imageResponse = await http.get(Uri.parse(imageUrl));
+      var imageResponse = await http.get(Uri.parse(image.imageUrl));
       await file.writeAsBytes(imageResponse.bodyBytes);
     }
 
     // Set the wallpaper to the downloaded image path
     pictureUri = file.path;
   }
+}
+class ImageProvider {
+  final String apiUrl;
+  final Function getImageUrl;
+  final Function getImageMetadata;
+  ImageProvider({
+    required this.apiUrl,
+    required this.getImageMetadata,
+    required this.getImageUrl,
+  });
+}
+class ImageModel {
+  final String imageUrl;
+  final String imageMetadata;
+  ImageModel({
+    required this.imageUrl,
+    required this.imageMetadata,
+  });
 }
 
 enum ColorShadingType {

--- a/lib/view/pages/wallpaper/wallpaper_model.dart
+++ b/lib/view/pages/wallpaper/wallpaper_model.dart
@@ -189,13 +189,18 @@ class WallpaperModel extends SafeChangeNotifier {
               getImageUrl: (json) {
                 return _bingUrl + json['images'][0]['url'];
               },
-              getImageMetadata: (json) => json['images'][0]['copyright'].replaceAll('/', ' - '),);
+              getImageMetadata: (json) =>
+                  json['images'][0]['copyright'].replaceAll('/', ' - '),
+            );
           }
-        case ImageOfTheDayProvider.nasa: {
+        case ImageOfTheDayProvider.nasa:
+          {
             return ImageProvider(
               apiUrl: _nasaUrl,
-              getImageUrl: (json) => json['hdurl']??json['url'],
-              getImageMetadata: (json) => '${json['title']}  (© ${json['copyright']})',);
+              getImageUrl: (json) => json['hdurl'] ?? json['url'],
+              getImageMetadata: (json) =>
+                  '${json['title']}  (© ${json['copyright']})',
+            );
           }
       }
     }
@@ -208,16 +213,17 @@ class WallpaperModel extends SafeChangeNotifier {
       var decodedJson = json.decode(imageMetadataResponse.body);
       return ImageModel(
         imageUrl: currentProvider.getImageUrl(decodedJson),
-        imageMetadata: currentProvider
-            .getImageMetadata(decodedJson),
+        imageMetadata: currentProvider.getImageMetadata(decodedJson),
       );
     }
+
     ImageModel image = await getImageUrl();
 
     //TODO: Save the images to a more suitable location
-    String path = '${directory.path}/ImageOfTheDay/${imageOfTheDayProvider.name}/';
+    String path =
+        '${directory.path}/ImageOfTheDay/${imageOfTheDayProvider.name}/';
     bool exists = await Directory(path).exists();
-    if(!exists) {
+    if (!exists) {
       await Directory(path).create(recursive: true);
     }
     //TODO: Embed the copyright info in the metadata instead of the filename
@@ -234,6 +240,7 @@ class WallpaperModel extends SafeChangeNotifier {
     pictureUri = file.path;
   }
 }
+
 class ImageProvider {
   final String apiUrl;
   final Function getImageUrl;
@@ -244,6 +251,7 @@ class ImageProvider {
     required this.getImageUrl,
   });
 }
+
 class ImageModel {
   final String imageUrl;
   final String imageMetadata;

--- a/lib/view/pages/wallpaper/wallpaper_model.dart
+++ b/lib/view/pages/wallpaper/wallpaper_model.dart
@@ -67,6 +67,10 @@ class WallpaperModel extends SafeChangeNotifier {
     notifyListeners();
   }
 
+  String get caption =>
+      pictureUri.split('/').last.replaceFirst('.jpeg', '');
+
+
   Future<void> copyToCollection(String picPathString) async {
     File image = File(picPathString);
     if (_userWallpapersDir == null) return;

--- a/lib/view/pages/wallpaper/wallpaper_model.dart
+++ b/lib/view/pages/wallpaper/wallpaper_model.dart
@@ -67,9 +67,7 @@ class WallpaperModel extends SafeChangeNotifier {
     notifyListeners();
   }
 
-  String get caption =>
-      pictureUri.split('/').last.replaceFirst('.jpeg', '');
-
+  String get caption => pictureUri.split('/').last.replaceFirst('.jpeg', '');
 
   Future<void> copyToCollection(String picPathString) async {
     File image = File(picPathString);

--- a/lib/view/pages/wallpaper/wallpaper_model.dart
+++ b/lib/view/pages/wallpaper/wallpaper_model.dart
@@ -189,13 +189,13 @@ class WallpaperModel extends SafeChangeNotifier {
               getImageUrl: (json) {
                 return _bingUrl + json['images'][0]['url'];
               },
-              getImageMetadata: (json) => json['images'][0]['copyright'].replaceAll('/', ' - '));
+              getImageMetadata: (json) => json['images'][0]['copyright'].replaceAll('/', ' - '),);
           }
         case ImageOfTheDayProvider.nasa: {
             return ImageProvider(
               apiUrl: _nasaUrl,
               getImageUrl: (json) => json['hdurl']??json['url'],
-              getImageMetadata: (json) => '${json['title']}  (© ${json['copyright']})');
+              getImageMetadata: (json) => '${json['title']}  (© ${json['copyright']})',);
           }
       }
     }

--- a/lib/view/pages/wallpaper/wallpaper_model.dart
+++ b/lib/view/pages/wallpaper/wallpaper_model.dart
@@ -194,7 +194,7 @@ class WallpaperModel extends SafeChangeNotifier {
         case ImageOfTheDayProvider.nasa: {
             return ImageProvider(
               apiUrl: _nasaUrl,
-              getImageUrl: (json) => json['url'],
+              getImageUrl: (json) => json['hdurl']??json['url'],
               getImageMetadata: (json) => '${json['title']}  (© ${json['copyright']})');
           }
       }

--- a/lib/view/pages/wallpaper/wallpaper_model.dart
+++ b/lib/view/pages/wallpaper/wallpaper_model.dart
@@ -190,7 +190,8 @@ class WallpaperModel extends SafeChangeNotifier {
                 return _bingUrl + json['images'][0]['url'];
               },
               getImageMetadata: (json) =>
-                  json['images'][0]['copyright'].replaceAll('/', ' - '),
+                  json['images'][0]['copyright'].replaceAll('/', ' - ') ??
+                  '(© Bing)',
             );
           }
         case ImageOfTheDayProvider.nasa:
@@ -199,7 +200,7 @@ class WallpaperModel extends SafeChangeNotifier {
               apiUrl: _nasaUrl,
               getImageUrl: (json) => json['hdurl'] ?? json['url'],
               getImageMetadata: (json) =>
-                  '${json['title']}  (© ${json['copyright']})',
+                  '${json['title'] == null ? '' : json['title'] + ' '}(© ${json['copyright'] ?? 'NASA'})',
             );
           }
       }

--- a/lib/view/pages/wallpaper/wallpaper_page.dart
+++ b/lib/view/pages/wallpaper/wallpaper_page.dart
@@ -101,7 +101,7 @@ class WallpaperPage extends StatelessWidget {
               child: Padding(
                 padding: const EdgeInsets.only(left: 5, bottom: 15),
                 child: Text(
-                  model.pictureUri.split('/').last.replaceFirst('.jpeg', ''),
+                  model.caption,
                   style: Theme.of(context).textTheme.caption!.copyWith(
                         fontStyle: FontStyle.italic,
                       ),

--- a/lib/view/pages/wallpaper/wallpaper_page.dart
+++ b/lib/view/pages/wallpaper/wallpaper_page.dart
@@ -99,7 +99,7 @@ class WallpaperPage extends StatelessWidget {
             child: Align(
               alignment: AlignmentDirectional.centerStart,
               child: Padding(
-                padding: const EdgeInsets.only(left: 5),
+                padding: const EdgeInsets.only(left: 5, bottom: 15),
                 child: Text(
                   model.pictureUri.split('/').last.replaceFirst('.jpeg', ''),
                   style: Theme.of(context).textTheme.caption!.copyWith(

--- a/lib/view/pages/wallpaper/wallpaper_page.dart
+++ b/lib/view/pages/wallpaper/wallpaper_page.dart
@@ -101,7 +101,7 @@ class WallpaperPage extends StatelessWidget {
                   child: Text(model.pictureUri
                       .split('/')
                       .last
-                      .replaceFirst('.jpeg', '')))),
+                      .replaceFirst('.jpeg', ''),),),),
                                     
         if (model.wallpaperMode == WallpaperMode.imageOfTheDay)
           YaruTile(

--- a/lib/view/pages/wallpaper/wallpaper_page.dart
+++ b/lib/view/pages/wallpaper/wallpaper_page.dart
@@ -93,6 +93,16 @@ class WallpaperPage extends StatelessWidget {
                   selected: false,
                 ),
         ),
+        if (model.wallpaperMode == WallpaperMode.imageOfTheDay) 
+          SizedBox(
+              width: kDefaultWidth,
+              child: Align(
+                  alignment: AlignmentDirectional.centerStart,
+                  child: Text(model.pictureUri
+                      .split('/')
+                      .last
+                      .replaceFirst('.jpeg', '')))),
+                                    
         if (model.wallpaperMode == WallpaperMode.imageOfTheDay)
           YaruTile(
             leading:

--- a/lib/view/pages/wallpaper/wallpaper_page.dart
+++ b/lib/view/pages/wallpaper/wallpaper_page.dart
@@ -94,57 +94,68 @@ class WallpaperPage extends StatelessWidget {
                 ),
         ),
         if (model.wallpaperMode == WallpaperMode.imageOfTheDay)
-          SizedBox(
-            width: kDefaultWidth,
-            child: Align(
-              alignment: AlignmentDirectional.centerStart,
-              child: Padding(
-                padding: const EdgeInsets.only(left: 5, bottom: 15),
-                child: Text(
-                  model.caption,
-                  style: Theme.of(context).textTheme.caption!.copyWith(
-                        fontStyle: FontStyle.italic,
-                      ),
+          Column(
+            children: [
+              SizedBox(
+                width: kDefaultWidth,
+                child: Align(
+                  alignment: AlignmentDirectional.centerStart,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 5),
+                    child: Text(
+                      model.caption,
+                      style: Theme.of(context).textTheme.caption!.copyWith(
+                            fontStyle: FontStyle.italic,
+                          ),
+                    ),
+                  ),
                 ),
               ),
-            ),
-          ),
-        if (model.wallpaperMode == WallpaperMode.imageOfTheDay)
-          YaruTile(
-            leading:
-                Text(context.l10n.wallpaperPageBackgroundModeImageOfTheDay),
-            title: YaruPopupMenuButton<ImageOfTheDayProvider>(
-              child: Text(model.imageOfTheDayProvider.localize(context.l10n)),
-              initialValue: model.imageOfTheDayProvider,
-              itemBuilder: (context) {
-                return [
-                  for (final provider in ImageOfTheDayProvider.values)
-                    PopupMenuItem(
-                      value: provider,
-                      onTap: () => model.setUrlWallpaperProvider(provider),
-                      child: Text(
-                        provider.localize(context.l10n),
-                      ),
-                    )
-                ];
-              },
-            ),
-            trailing: YaruOptionButton(
-              onPressed: () async {
-                await model.refreshUrlWallpaper();
-                if (model.errorMessage.isNotEmpty) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text(
-                        model.errorMessage,
-                        style: TextStyle(color: Theme.of(context).primaryColor),
-                      ),
-                    ),
-                  );
-                }
-              },
-              child: const Icon(YaruIcons.refresh),
-            ),
+              const SizedBox(
+                height: 15,
+              ),
+              YaruTile(
+                leading: Text(
+                  context.l10n.wallpaperPageBackgroundModeImageOfTheDay,
+                ),
+                title: YaruPopupMenuButton<ImageOfTheDayProvider>(
+                  child: Text(
+                    model.imageOfTheDayProvider.localize(context.l10n),
+                  ),
+                  initialValue: model.imageOfTheDayProvider,
+                  itemBuilder: (context) {
+                    return [
+                      for (final provider in ImageOfTheDayProvider.values)
+                        PopupMenuItem(
+                          value: provider,
+                          onTap: () => model.setUrlWallpaperProvider(provider),
+                          child: Text(
+                            provider.localize(context.l10n),
+                          ),
+                        )
+                    ];
+                  },
+                ),
+                trailing: YaruOptionButton(
+                  onPressed: () async {
+                    await model.refreshUrlWallpaper();
+                    if (model.errorMessage.isNotEmpty) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text(
+                            model.errorMessage,
+                            style: TextStyle(
+                              color: Theme.of(context).primaryColor,
+                            ),
+                          ),
+                        ),
+                      );
+                    }
+                  },
+                  child: const Icon(YaruIcons.refresh),
+                ),
+              ),
+            ],
           ),
         if (model.wallpaperMode == WallpaperMode.custom)
           Column(

--- a/lib/view/pages/wallpaper/wallpaper_page.dart
+++ b/lib/view/pages/wallpaper/wallpaper_page.dart
@@ -98,8 +98,14 @@ class WallpaperPage extends StatelessWidget {
             width: kDefaultWidth,
             child: Align(
               alignment: AlignmentDirectional.centerStart,
-              child: Text(
-                model.pictureUri.split('/').last.replaceFirst('.jpeg', ''),
+              child: Padding(
+                padding: const EdgeInsets.only(left: 5),
+                child: Text(
+                  model.pictureUri.split('/').last.replaceFirst('.jpeg', ''),
+                  style: Theme.of(context).textTheme.caption!.copyWith(
+                        fontStyle: FontStyle.italic,
+                      ),
+                ),
               ),
             ),
           ),

--- a/lib/view/pages/wallpaper/wallpaper_page.dart
+++ b/lib/view/pages/wallpaper/wallpaper_page.dart
@@ -93,16 +93,16 @@ class WallpaperPage extends StatelessWidget {
                   selected: false,
                 ),
         ),
-        if (model.wallpaperMode == WallpaperMode.imageOfTheDay) 
+        if (model.wallpaperMode == WallpaperMode.imageOfTheDay)
           SizedBox(
-              width: kDefaultWidth,
-              child: Align(
-                  alignment: AlignmentDirectional.centerStart,
-                  child: Text(model.pictureUri
-                      .split('/')
-                      .last
-                      .replaceFirst('.jpeg', ''),),),),
-                                    
+            width: kDefaultWidth,
+            child: Align(
+              alignment: AlignmentDirectional.centerStart,
+              child: Text(
+                model.pictureUri.split('/').last.replaceFirst('.jpeg', ''),
+              ),
+            ),
+          ),
         if (model.wallpaperMode == WallpaperMode.imageOfTheDay)
           YaruTile(
             leading:


### PR DESCRIPTION
Fix for #385 

I solved this by saving the image's title to the file name and view it under the image.

- Change the saving directory to `/Documents/ImageOfTheDay/providername/image.jpeg`
- Created two new classes to make it easier to add more providers
- Format the Nasa copyright info to be like bing's
- Used HD image from the NASA's api if available

I wanted to embed the copyright info to the image actual metadata but couldn't do it.