### PR TITLE
Set the preview image fit and aspect ratio to preview the wallpaper accuratly

### DIFF
--- a/lib/view/pages/wallpaper/wallpaper_page.dart
+++ b/lib/view/pages/wallpaper/wallpaper_page.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:settings/constants.dart';
 import 'package:settings/l10n/l10n.dart';
 import 'package:settings/services/settings_service.dart';
+import 'package:settings/services/display/display_service.dart';
 import 'package:settings/utils.dart';
 import 'package:settings/view/pages/settings_page.dart';
 import 'package:settings/view/pages/wallpaper/color_shading_option_row.dart';
@@ -219,9 +220,18 @@ class _WallpaperImage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final service = Provider.of<DisplayService>(context, listen: false)
+        .currentNotifier
+        .value;
+    double aspectRatio = 16 / 9;
+
+    if (service != null) {
+      final resolution = service.configurations.first.resolution.split('x');
+      aspectRatio = (int.parse(resolution.first) / int.parse(resolution.last));
+    }
+
     return AspectRatio(
-      // TODO: Set it to the aspect ratio of the device screen
-      aspectRatio: 16 / 9,
+      aspectRatio: aspectRatio,
       child: Image.file(
         File(path),
         filterQuality: FilterQuality.none,

--- a/lib/view/pages/wallpaper/wallpaper_page.dart
+++ b/lib/view/pages/wallpaper/wallpaper_page.dart
@@ -8,6 +8,7 @@ import 'package:settings/l10n/l10n.dart';
 import 'package:settings/services/settings_service.dart';
 import 'package:settings/services/display/display_service.dart';
 import 'package:settings/utils.dart';
+import 'package:settings/view/pages/displays/displays_configuration.dart';
 import 'package:settings/view/pages/settings_page.dart';
 import 'package:settings/view/pages/wallpaper/color_shading_option_row.dart';
 import 'package:settings/view/pages/wallpaper/wallpaper_model.dart';
@@ -38,6 +39,22 @@ class WallpaperPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final model = context.watch<WallpaperModel>();
+    final displayService = context.watch<DisplayService>();
+
+    double getAspectRatio() {
+      DisplaysConfiguration? displaysConfiguration =
+          displayService.currentNotifier.value;
+      if (displaysConfiguration != null) {
+        final resolution =
+            displaysConfiguration.configurations.first.resolution.split('x');
+        double aspectRatio =
+            (int.parse(resolution.first) / int.parse(resolution.last));
+        return aspectRatio;
+      }
+      //Default aspect ratio
+      return 16 / 9;
+    }
+
     const headlineInsets =
         EdgeInsets.only(top: 30, left: 10, right: 10, bottom: 10);
 
@@ -73,17 +90,20 @@ class WallpaperPage extends StatelessWidget {
         ),
         SizedBox(
           width: kDefaultWidth,
-          child: pictureUri.isEmpty
-              ? ChangeNotifierProvider.value(
-                  value: model,
-                  child: const _ColoredBackground(),
-                )
-              : YaruSelectableContainer(
-                  child: _WallpaperImage(
-                    path: pictureUri.replaceAll(gnomeWallpaperSuffix, ''),
+          child: AspectRatio(
+            aspectRatio: getAspectRatio(),
+            child: pictureUri.isEmpty
+                ? ChangeNotifierProvider.value(
+                    value: model,
+                    child: const _ColoredBackground(),
+                  )
+                : YaruSelectableContainer(
+                    child: _WallpaperImage(
+                      path: pictureUri.replaceAll(gnomeWallpaperSuffix, ''),
+                    ),
+                    selected: false,
                   ),
-                  selected: false,
-                ),
+          ),
         ),
         if (model.wallpaperMode == WallpaperMode.solid)
           ColorShadingOptionRow(
@@ -220,24 +240,11 @@ class _WallpaperImage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final service = Provider.of<DisplayService>(context, listen: false)
-        .currentNotifier
-        .value;
-    double aspectRatio = 16 / 9;
-
-    if (service != null) {
-      final resolution = service.configurations.first.resolution.split('x');
-      aspectRatio = (int.parse(resolution.first) / int.parse(resolution.last));
-    }
-
-    return AspectRatio(
-      aspectRatio: aspectRatio,
-      child: Image.file(
-        File(path),
-        filterQuality: FilterQuality.none,
-        fit: BoxFit.cover,
-        cacheHeight: height,
-      ),
+    return Image.file(
+      File(path),
+      filterQuality: FilterQuality.none,
+      fit: BoxFit.cover,
+      cacheHeight: height,
     );
   }
 }

--- a/lib/view/pages/wallpaper/wallpaper_page.dart
+++ b/lib/view/pages/wallpaper/wallpaper_page.dart
@@ -219,11 +219,15 @@ class _WallpaperImage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Image.file(
-      File(path),
-      filterQuality: FilterQuality.none,
-      fit: BoxFit.fill,
-      cacheHeight: height,
+    return AspectRatio(
+      // TODO: Set it to the aspect ratio of the device screen
+      aspectRatio: 16 / 9,
+      child: Image.file(
+        File(path),
+        filterQuality: FilterQuality.none,
+        fit: BoxFit.cover,
+        cacheHeight: height,
+      ),
     );
   }
 }


### PR DESCRIPTION
Before (sometimes):
![Screenshot from 2022-11-26 17-20-10](https://user-images.githubusercontent.com/28854622/204096402-6f276b03-a171-4c62-b169-f6f580d8fad1.png)

After:
![Screenshot from 2022-11-26 17-19-56](https://user-images.githubusercontent.com/28854622/204096406-48afba39-5062-4564-b60c-62dad073b840.png)

Next would be to get the screen's actual aspect ratio but currently it is not supported by google and can only be done by adding [window_size](https://github.com/google/flutter-desktop-embedding/tree/main/plugins/window_size) manually