### PR TITLE
Use gtk_window to replace native headerBar

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localized_locales/flutter_localized_locales.dart';
+import 'package:gtk_window/gtk_window.dart';
 import 'package:settings/l10n/l10n.dart';
 import 'package:settings/view/pages/page_items.dart';
 import 'package:settings/view/pages/settings_page_item.dart';
@@ -41,6 +42,7 @@ class _UbuntuSettingsAppState extends State<UbuntuSettingsApp> {
     });
   }
 
+  bool isExpanded = true;
   @override
   Widget build(BuildContext context) {
     return YaruTheme(
@@ -67,21 +69,42 @@ class _UbuntuSettingsAppState extends State<UbuntuSettingsApp> {
                 ),
                 pageBuilder: (context, index) => YaruDetailPage(
                   body: pages[index].builder(context),
-                  appBar: AppBar(
-                    title: pages[index].titleBuilder(context),
-                    leading: Navigator.of(context).canPop()
-                        ? const YaruBackButton()
-                        : null,
+                  appBar: GTKHeaderBar(
+                    middle: pages[index].titleBuilder(context),
                   ),
                 ),
-                appBar: SearchAppBar(
-                  searchHint: context.l10n.searchHint,
-                  clearSearchIconData: YaruIcons.window_close,
-                  searchController: _searchController,
-                  onChanged: (v) => _onSearchChanged(v, context),
-                  onEscape: _onEscape,
-                  appBarHeight: 48,
-                  searchIconData: YaruIcons.search,
+                appBar: GTKHeaderBar(
+                  middleSpacing: 0,
+                  padding: isExpanded
+                      ? EdgeInsets.zero
+                      : const EdgeInsets.symmetric(horizontal: 10),
+                  middle: const Text('Settings'),
+                  showWindowControlsButtons: !isExpanded,
+                  onWindowResize: (size) {
+                    if (size.width > kYaruMasterDetailBreakpoint) {
+                      if (isExpanded == false) {
+                        setState(() {
+                          isExpanded = true;
+                        });
+                      }
+                    } else if (isExpanded == true) {
+                      setState(() {
+                        isExpanded = false;
+                      });
+                    }
+                  },
+                  bottom: PreferredSize(
+                    preferredSize: const Size.fromHeight(48),
+                    child: SearchAppBar(
+                      searchHint: context.l10n.searchHint,
+                      clearSearchIconData: YaruIcons.window_close,
+                      searchController: _searchController,
+                      onChanged: (v) => _onSearchChanged(v, context),
+                      onEscape: _onEscape,
+                      appBarHeight: 48,
+                      searchIconData: YaruIcons.search,
+                    ),
+                  ),
                 ),
               );
             },

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -8,7 +8,9 @@
 
 #include <file_selector_linux/file_selector_plugin.h>
 #include <handy_window/handy_window_plugin.h>
+#include <screen_retriever/screen_retriever_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
+#include <window_manager/window_manager_plugin.h>
 #include <yaru/yaru_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
@@ -18,9 +20,15 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) handy_window_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "HandyWindowPlugin");
   handy_window_plugin_register_with_registrar(handy_window_registrar);
+  g_autoptr(FlPluginRegistrar) screen_retriever_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverPlugin");
+  screen_retriever_plugin_register_with_registrar(screen_retriever_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
+  g_autoptr(FlPluginRegistrar) window_manager_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
+  window_manager_plugin_register_with_registrar(window_manager_registrar);
   g_autoptr(FlPluginRegistrar) yaru_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "YaruPlugin");
   yaru_plugin_register_with_registrar(yaru_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -5,7 +5,9 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
   handy_window
+  screen_retriever
   url_launcher_linux
+  window_manager
   yaru
 )
 

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -125,25 +125,25 @@ static void my_application_activate(GApplication* application) {
   // in case the window manager does more exotic layout, e.g. tiling.
   // If running on Wayland assume the header bar will work (may need changing
   // if future cases occur).
-  gboolean use_header_bar = TRUE;
-#ifdef GDK_WINDOWING_X11
-  GdkScreen* screen = gtk_window_get_screen(window);
-  if (GDK_IS_X11_SCREEN(screen)) {
-    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
-    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
-      use_header_bar = FALSE;
-    }
-  }
-#endif
-  if (use_header_bar) {
-    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
-    gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "Ubuntu Settings");
-    gtk_header_bar_set_show_close_button(header_bar, TRUE);
-    gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
-  } else {
-    gtk_window_set_title(window, "settings");
-  }
+//   gboolean use_header_bar = TRUE;
+// #ifdef GDK_WINDOWING_X11
+//   GdkScreen* screen = gtk_window_get_screen(window);
+//   if (GDK_IS_X11_SCREEN(screen)) {
+//     const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
+//     if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
+//       use_header_bar = FALSE;
+//     }
+//   }
+// #endif
+//   if (use_header_bar) {
+//     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
+//     gtk_widget_show(GTK_WIDGET(header_bar));
+//     gtk_header_bar_set_title(header_bar, "Ubuntu Settings");
+//     gtk_header_bar_set_show_close_button(header_bar, TRUE);
+//     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
+//   } else {
+//     gtk_window_set_title(window, "settings");
+//   }
 
   GdkGeometry geometry;
   geometry.min_width = 600;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -378,6 +378,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.5"
+  gtk_window:
+    dependency: "direct main"
+    description:
+      name: gtk_window
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1"
   handy_window:
     dependency: "direct main"
     description:
@@ -702,6 +709,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.0+1"
+  screen_retriever:
+    dependency: transitive
+    description:
+      name: screen_retriever
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   shelf:
     dependency: transitive
     description:
@@ -952,6 +966,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.6.1"
+  window_manager:
+    dependency: transitive
+    description:
+      name: window_manager
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.8"
   xdg_directories:
     dependency: transitive
     description:
@@ -1016,5 +1037,5 @@ packages:
     source: hosted
     version: "2.0.0-beta-2"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=2.18.5 <3.0.0"
   flutter: ">=3.3.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,8 @@ dependencies:
   flutter_spinbox: ^0.9.0
   flutter_svg: ^1.0.3
   gsettings: ^0.2.5
-  handy_window: ^0.1.9
+  gtk_window: ^0.0.1
+  handy_window: ^0.1.4
   http: ^0.13.4
   intl: ^0.17.0
   linux_system_info:


### PR DESCRIPTION

Before             |  After
:-------------------------:|:-------------------------:
![Screenshot from 2022-12-11 23-24-42](https://user-images.githubusercontent.com/28854622/206929605-932fadb1-fda7-481d-9f6f-fc14ead5ac4b.png) |  ![Screenshot from 2022-12-11 23-17-16](https://user-images.githubusercontent.com/28854622/206929301-32dbb2ef-135f-42c4-89c7-ef1f66cdaa8b.png)
![Screenshot from 2022-12-11 23-20-26](https://user-images.githubusercontent.com/28854622/206929451-3a84c887-14dd-4110-9f6c-1018320c4eff.png)|![Screenshot from 2022-12-11 23-17-08](https://user-images.githubusercontent.com/28854622/206929312-55bd5fea-66fb-45a5-9a5f-d338f8f664cf.png)
![Screenshot from 2022-12-11 23-20-33](https://user-images.githubusercontent.com/28854622/206929444-0f95b670-39f4-4406-afad-cea260549490.png) |![Screenshot from 2022-12-11 23-17-02](https://user-images.githubusercontent.com/28854622/206929315-eb30b7b0-bd04-4d59-be61-3f55bf119e87.png)

gtk_appbar is a flutter "fake" appbar that works as a drop in replacement for the Material AppBar. It will allow us to add flutter widgets like these examples from the official app. 
![Screenshot from 2022-12-11 23-35-02](https://user-images.githubusercontent.com/28854622/206930123-5a8186b6-d5bc-42c6-b6fd-21497173bd44.png)
![Screenshot from 2022-12-11 23-34-30](https://user-images.githubusercontent.com/28854622/206930125-282a1abb-8340-4d26-b9e3-59ae0d3cf1a5.png)
It just feels right to have full control over the headerbar of your linux app and it allows you adopt styles like gtk4 without waiting for google to implement them.

